### PR TITLE
Fixed initialstate not being loaded which caused showshare to not work

### DIFF
--- a/apps/core/templates/layout.guest.php
+++ b/apps/core/templates/layout.guest.php
@@ -6,16 +6,24 @@
 
 <body id="<?php p($_['bodyid']); ?>">
 	<?php if ($_['bodyid'] === 'body-login'): ?>
+		<?php include \OC::$SERVERROOT . '/core/templates/layout.noscript.warning.php'; ?>
+		<?php include \OC::$SERVERROOT . '/core/templates/layout.initial-state.php'; ?>
 		<?php include 'components/header.html'; ?>
 		<div id="page">
+			<?php $show_share = strpos($_SERVER['REQUEST_URI'], 'showshare') !== false; ?>
+			
 			<div class="container" id="b2access-login">
 				<div class="description-home">
-					<div id="oidc-select-user-back-end">
-						<h1>Anmeldeoptionen:</h1>
-						<div class="login-option">
-							<a href="/apps/user_oidc/login/1?redirectUrl=">B2ACCESS</a>
+					<?php if ($show_share): ?>
+					<?php print_unescaped($_['content']); ?>
+					<?php else: ?>
+						<div id="oidc-select-user-back-end">
+							<h1>Anmeldeoptionen:</h1>
+							<div class="login-option">
+								<a href="/apps/user_oidc/login/1?redirectUrl=">B2ACCESS</a>
+							</div>
 						</div>
-					</div>
+					<?php endif; ?>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Initialstate was not being loaded properly probably due to the guest layout being replaced by the theme which caused it to try to look in the theme directory for the initalstate code.

Added a check whether the uri contains showshare to decide if it is the login page or the showshare.